### PR TITLE
[Feat] 채팅 응답과 감정 분석 요청을 분리

### DIFF
--- a/src/main/java/psychat/backend/BackendApplication.java
+++ b/src/main/java/psychat/backend/BackendApplication.java
@@ -3,8 +3,10 @@ package psychat.backend;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @EnableJpaAuditing
+@EnableAsync
 @SpringBootApplication
 public class BackendApplication {
 

--- a/src/main/java/psychat/backend/chatting/domain/UserMessage.java
+++ b/src/main/java/psychat/backend/chatting/domain/UserMessage.java
@@ -34,11 +34,14 @@ public class UserMessage {
     @Column(updatable = false)
     private LocalDateTime startTime;
 
-    public static UserMessage of(Session session, String messageContent, String emotion) {
+    public static UserMessage of(Session session, String messageContent) {
         return UserMessage.builder()
                 .session(session)
                 .messageContent(messageContent)
-                .emotion(emotion)
                 .build();
+    }
+
+    public void update(String emotion) {
+        this.emotion = emotion;
     }
 }

--- a/src/main/java/psychat/backend/chatting/dto/response/EmotionJudgeResponse.java
+++ b/src/main/java/psychat/backend/chatting/dto/response/EmotionJudgeResponse.java
@@ -1,13 +1,15 @@
 package psychat.backend.chatting.dto.response;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
 @AllArgsConstructor
-public class ChatbotResponse {
+@NoArgsConstructor
+@Builder
+public class EmotionJudgeResponse {
 
-    private String responseContent;
+    private int emotion;
 }

--- a/src/main/java/psychat/backend/chatting/service/EmotionService.java
+++ b/src/main/java/psychat/backend/chatting/service/EmotionService.java
@@ -1,11 +1,25 @@
 package psychat.backend.chatting.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
+import org.springframework.http.*;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
 import psychat.backend.chatting.domain.Emotion;
+import psychat.backend.chatting.domain.UserMessage;
+import psychat.backend.chatting.dto.request.ChatbotRequest;
+import psychat.backend.chatting.dto.request.ChattingRequest;
+import psychat.backend.chatting.dto.response.EmotionJudgeResponse;
 import psychat.backend.chatting.repository.EmotionRepository;
+import psychat.backend.chatting.repository.UserMessageRepository;
+import psychat.backend.global.exception.JsonConvertException;
 import psychat.backend.global.exception.NotFoundException;
 
 import java.io.BufferedReader;
@@ -13,13 +27,20 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class EmotionService {
 
-    private final ResourceLoader resourceLoader;
+    @Value("${EMOTION_JUDGE_URL}")
+    private String emotionUrl;
 
+    private final ResourceLoader resourceLoader;
+    private final ObjectMapper objectMapper;
+
+    private final UserMessageRepository userMessageRepository;
     private final EmotionRepository emotionRepository;
 
     public String convert(Long emotionIndex) {
@@ -29,6 +50,41 @@ public class EmotionService {
         return emotion.getType();
     }
 
+    @Async
+    @Transactional
+    public void processEmotion(ChattingRequest request, Long userMessageId) {
+        ChatbotRequest emotionRequest = ChatbotRequest.of(request.getMessageContent());
+        Map<Long, Map<Integer, Integer>> sessionIndexMap = ChattingService.getIndexMap();
+        try {
+            String jsonString = objectMapper.writeValueAsString(emotionRequest);
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            HttpEntity<String> requestEntity = new HttpEntity<>(jsonString, headers);
+
+            RestTemplate restTemplate = new RestTemplate();
+            ResponseEntity<String> responseEntity =
+                    restTemplate.exchange(emotionUrl, HttpMethod.POST, requestEntity, String.class);
+
+            EmotionJudgeResponse response = objectMapper.readValue(responseEntity.getBody(), EmotionJudgeResponse.class);
+
+            String emotionResult = convert((long) response.getEmotion());
+            log.info("emotion : {}", emotionResult);
+
+            Map<Integer, Integer> emotionAndFrequency = sessionIndexMap.get(request.getSessionId());
+            int key = response.getEmotion();
+            emotionAndFrequency.computeIfPresent(key, (k, v) -> v + 1);
+            emotionAndFrequency.putIfAbsent(key, 1);
+
+            UserMessage findUserMessage = userMessageRepository.findById(userMessageId)
+                    .orElseThrow(() -> new NotFoundException("유저 메시지가 존재하지 않습니다."));
+
+            findUserMessage.update(emotionResult);
+
+        } catch (JsonProcessingException e) {
+            throw new JsonConvertException("JSON이 올바르지 않습니다.");
+        }
+    }
     public void fill() {
         Resource resource = resourceLoader.getResource("classpath:wellness_dialog_category.txt");
 


### PR DESCRIPTION
issue-11번에 대한 내용을 구현하였습니다.

감정 분석 모델에 요청하는 것을 @Async를 활용한 비동기 로직으로 처리했습니다.

- 기존 채팅 응답 API가 45->26초 정도로 성능이 향상됐고,
- 비동기적으로 감정 분석이 완료되고 DB에 저장되는 것을 확인했습니다.