### PR TITLE
[Feat] 대화 내역 단건 조회

### DIFF
--- a/src/main/java/psychat/backend/chatting/api/ChattingApi.java
+++ b/src/main/java/psychat/backend/chatting/api/ChattingApi.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import psychat.backend.chatting.dto.request.ChattingRequest;
 import psychat.backend.chatting.dto.request.EndRequest;
+import psychat.backend.chatting.dto.response.ChattingListResponse;
 import psychat.backend.chatting.dto.response.ChattingResponse;
 import psychat.backend.chatting.dto.response.EmotionResponse;
 import psychat.backend.chatting.dto.response.SessionResponse;
@@ -36,5 +37,10 @@ public class ChattingApi {
     @PostMapping("/end-chat")
     public EmotionResponse end(@RequestParam String token, @RequestBody EndRequest request) {
         return chattingService.end(token, request);
+    }
+
+    @GetMapping("/chat/{session-id}")
+    public ChattingListResponse chattingListBySessionId(@PathVariable("session-id") Long sessionId) {
+        return chattingService.chattingListBySessionId(sessionId);
     }
 }

--- a/src/main/java/psychat/backend/chatting/dto/response/ChattingListResponse.java
+++ b/src/main/java/psychat/backend/chatting/dto/response/ChattingListResponse.java
@@ -1,0 +1,25 @@
+package psychat.backend.chatting.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChattingListResponse {
+
+    private List<MessageResponse> userMessages;
+    private List<MessageResponse> botMessages;
+
+    public static ChattingListResponse of(List<MessageResponse> userMessages, List<MessageResponse> botMessages) {
+        return ChattingListResponse.builder()
+                .userMessages(userMessages)
+                .botMessages(botMessages)
+                .build();
+    }
+}

--- a/src/main/java/psychat/backend/chatting/dto/response/MessageResponse.java
+++ b/src/main/java/psychat/backend/chatting/dto/response/MessageResponse.java
@@ -1,0 +1,34 @@
+package psychat.backend.chatting.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import psychat.backend.chatting.domain.BotMessage;
+import psychat.backend.chatting.domain.UserMessage;
+
+import java.time.format.DateTimeFormatter;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MessageResponse {
+
+    private String messageContent;
+    private String timestamp;
+
+    public static MessageResponse of(UserMessage userMessage) {
+        return MessageResponse.builder()
+                .messageContent(userMessage.getMessageContent())
+                .timestamp(userMessage.getStartTime().format(DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm")))
+                .build();
+    }
+
+    public static MessageResponse of(BotMessage botMessage) {
+        return MessageResponse.builder()
+                .messageContent(botMessage.getMessageContent())
+                .timestamp(botMessage.getCreatedTime().format(DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm")))
+                .build();
+    }
+}

--- a/src/main/java/psychat/backend/chatting/repository/BotMessageRepository.java
+++ b/src/main/java/psychat/backend/chatting/repository/BotMessageRepository.java
@@ -2,6 +2,11 @@ package psychat.backend.chatting.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import psychat.backend.chatting.domain.BotMessage;
+import psychat.backend.chatting.domain.Session;
+
+import java.util.List;
 
 public interface BotMessageRepository extends JpaRepository<BotMessage, Long> {
+
+    List<BotMessage> findAllBySession(Session session);
 }

--- a/src/main/java/psychat/backend/chatting/repository/UserMessageRepository.java
+++ b/src/main/java/psychat/backend/chatting/repository/UserMessageRepository.java
@@ -1,7 +1,12 @@
 package psychat.backend.chatting.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import psychat.backend.chatting.domain.Session;
 import psychat.backend.chatting.domain.UserMessage;
 
+import java.util.List;
+
 public interface UserMessageRepository extends JpaRepository<UserMessage, Long> {
+
+    List<UserMessage> findAllBySession(Session session);
 }

--- a/src/main/java/psychat/backend/chatting/service/ChattingService.java
+++ b/src/main/java/psychat/backend/chatting/service/ChattingService.java
@@ -25,9 +25,12 @@ import psychat.backend.global.exception.NotFoundException;
 import psychat.backend.member.domain.Member;
 import psychat.backend.member.service.MemberService;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -95,6 +98,22 @@ public class ChattingService {
         sessionIndexMap.remove(findSession.getId());
 
         return EmotionResponse.of(emotion);
+    }
+
+    public ChattingListResponse chattingListBySessionId(Long sessionId) {
+        Session findSession = findBySessionId(sessionId);
+        List<UserMessage> userMessages = userMessageRepository.findAllBySession(findSession);
+        List<BotMessage> botMessages = botMessageRepository.findAllBySession(findSession);
+
+        List<MessageResponse> users = userMessages.stream()
+                .map(MessageResponse::of)
+                .collect(Collectors.toList());
+
+        List<MessageResponse> bots = botMessages.stream()
+                .map(MessageResponse::of)
+                .collect(Collectors.toList());
+
+        return ChattingListResponse.of(users, bots);
     }
 
     private int getEmotionResult(Long sessionId) {


### PR DESCRIPTION
메인 페이지의 채팅 내역 중 하나를 누르면 단건 조회를 할 수 있습니다.

이에 대응하기 위해,
- 채팅 단위 별 사용자와 챗봇의 모든 대화내역을 응답으로 전송합니다.
- 시간순의 오름차순으로 정렬합니다.