### PR TITLE
[Feat] 이전 채팅 내역 조회

### DIFF
--- a/src/main/java/psychat/backend/chatting/api/ChattingApi.java
+++ b/src/main/java/psychat/backend/chatting/api/ChattingApi.java
@@ -4,10 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import psychat.backend.chatting.dto.request.ChattingRequest;
 import psychat.backend.chatting.dto.request.EndRequest;
-import psychat.backend.chatting.dto.response.ChattingListResponse;
-import psychat.backend.chatting.dto.response.ChattingResponse;
-import psychat.backend.chatting.dto.response.EmotionResponse;
-import psychat.backend.chatting.dto.response.SessionResponse;
+import psychat.backend.chatting.dto.response.*;
 import psychat.backend.chatting.service.ChattingService;
 import psychat.backend.chatting.service.EmotionService;
 
@@ -42,5 +39,10 @@ public class ChattingApi {
     @GetMapping("/chat/{session-id}")
     public ChattingListResponse chattingListBySessionId(@PathVariable("session-id") Long sessionId) {
         return chattingService.chattingListBySessionId(sessionId);
+    }
+
+    @GetMapping("/previous-chats")
+    public PreviousChatListResponse previousChats(@RequestParam String token) {
+        return chattingService.previousChats(token);
     }
 }

--- a/src/main/java/psychat/backend/chatting/dto/response/PreviousChatListResponse.java
+++ b/src/main/java/psychat/backend/chatting/dto/response/PreviousChatListResponse.java
@@ -1,0 +1,23 @@
+package psychat.backend.chatting.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PreviousChatListResponse {
+
+    private List<PreviousChatResponse> previousChatList;
+
+    public static PreviousChatListResponse of(List<PreviousChatResponse> previousChatList) {
+        return PreviousChatListResponse.builder()
+                .previousChatList(previousChatList)
+                .build();
+    }
+}

--- a/src/main/java/psychat/backend/chatting/dto/response/PreviousChatResponse.java
+++ b/src/main/java/psychat/backend/chatting/dto/response/PreviousChatResponse.java
@@ -1,0 +1,28 @@
+package psychat.backend.chatting.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import psychat.backend.chatting.domain.Session;
+
+import java.time.format.DateTimeFormatter;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PreviousChatResponse {
+
+    private Long sessionId;
+    private String startDate;
+    private String emotion;
+
+    public static PreviousChatResponse of(Session session) {
+        return PreviousChatResponse.builder()
+                .sessionId(session.getId())
+                .startDate(session.getStartTime().format(DateTimeFormatter.ofPattern("yyyy.MM.dd")))
+                .emotion(session.getEmotion() == null ? "분석 결과 없음" : session.getEmotion())
+                .build();
+    }
+}

--- a/src/main/java/psychat/backend/chatting/repository/SessionRepository.java
+++ b/src/main/java/psychat/backend/chatting/repository/SessionRepository.java
@@ -1,11 +1,18 @@
 package psychat.backend.chatting.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import psychat.backend.chatting.domain.Session;
+import psychat.backend.member.domain.Member;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface SessionRepository extends JpaRepository<Session, Long> {
 
     Optional<Session> findById(Long id);
+
+    @Query("select s from Session s where s.member = :member order by s.id desc")
+    List<Session> findAllByMember(@Param("member") Member member);
 }

--- a/src/main/java/psychat/backend/chatting/service/ChattingService.java
+++ b/src/main/java/psychat/backend/chatting/service/ChattingService.java
@@ -116,6 +116,18 @@ public class ChattingService {
         return ChattingListResponse.of(users, bots);
     }
 
+    public PreviousChatListResponse previousChats(String token) {
+        Member findMember = memberService.findByToken(token);
+
+        List<Session> sessions = sessionRepository.findAllByMember(findMember);
+
+        List<PreviousChatResponse> previousChatList = sessions.stream()
+                .map(PreviousChatResponse::of)
+                .collect(Collectors.toList());
+
+        return PreviousChatListResponse.of(previousChatList);
+    }
+
     private int getEmotionResult(Long sessionId) {
         Map<Integer, Integer> emotionAndFrequency = sessionIndexMap.get(sessionId);
 


### PR DESCRIPTION
- token 기반 유저 식별
- 유저의 모든 채팅 내역을 API응답에 맞게 전달
- 채팅 시작 시간을 기준으로 최근것이 앞으로 오도록 정렬